### PR TITLE
Add support for decoding using a local function and improve term decoding speed

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -5,7 +5,7 @@
       rules => [
         {elvis_style, dont_repeat_yourself, #{min_complexity => 10}},
         {elvis_style, god_modules, #{limit => 25}},
-        {elvis_style, invalid_dynamic_call, #{ignore => []}},
+        {elvis_style, invalid_dynamic_call, #{ignore => [rig_utils]}},
         {elvis_style, line_length, #{limit => 80, skip_comments => false}},
         {elvis_style, macro_module_names},
         {elvis_style, macro_names},

--- a/include/rig.hrl
+++ b/include/rig.hrl
@@ -23,7 +23,7 @@
 %% types
 -type basedir() :: string().
 -type config()  :: {table(), file(), decoder(), options()}.
--type decoder() :: fun((binary()) -> tuple()) | term.
+-type decoder() :: fun((binary()) -> tuple()) | term | {module, module()}.
 -type file()    :: string().
 -type key()     :: term().
 -type option()  :: {key_element, pos_integer()} | {subscribers, [pid()]}.

--- a/test/rig_tests.erl
+++ b/test/rig_tests.erl
@@ -17,26 +17,25 @@ rig_test() ->
         {creatives, "./test/files/creatives.bert", term, []},
         {"./test/files/", [
             {domains, "domains.bert", term, [{key_element, 2}]},
+            {dummy, "domains.bert", {module, test_config}, [{key_element, 3}]},
             {invalid_fun, "invalid.bert", "my_fun:decode/1.", []}
         ]},
         {invalid_file, "", ?DECODER, []},
         {users, "./test/files/users.bert", ?DECODER, [{key_element, 2},
             {subscribers, [rig_test]}]}
     ]),
-    application:set_env(?APP, reload_delay, 500),
-    {ok, _} = rig_app:start(),
 
     encode_bert_configs(),
-    encode_bert_configs(),
-    encode_bert_configs(),
+    {ok, _} = rig_app:start(),
 
     receive {rig_index, update, users} ->
         ok
     end,
-    Count = length(ets:all()) - 4,
+    Count = length(ets:all()) - 5,
 
     {ok, {domain, 1 , <<"adgear.com">>}} = rig:read(domains, 1),
     {ok, {domain, 1 , <<"adgear.com">>}} = rig:read(domains, 1, undefined),
+    {ok, {domain, 5 , <<"foobar.com">>}} = rig:read(dummy, <<"foobar.com">>),
 
     {error, unknown_key} = rig:read(domains, 6),
     {ok, undefined} = rig:read(domains, 6, undefined),

--- a/test/test_config.erl
+++ b/test/test_config.erl
@@ -1,0 +1,8 @@
+-module(test_config).
+
+-export([
+    dummy/1
+]).
+
+dummy(_Bin) ->
+    {domain, 5 , <<"foobar.com">>}.


### PR DESCRIPTION
Documentation incoming after review. See http://erlang.org/doc/efficiency_guide/functions.html#function-calls. I get about the same ~3x speedup when testing locally.

Thanks to @rkallos for fixing the race condition in https://github.com/lpgauth/rig/issues/8