### PR TITLE
Add support for decoding using a local function

### DIFF
--- a/include/rig.hrl
+++ b/include/rig.hrl
@@ -23,7 +23,7 @@
 %% types
 -type basedir() :: string().
 -type config()  :: {table(), file(), decoder(), options()}.
--type decoder() :: fun((binary()) -> tuple()) | term.
+-type decoder() :: fun((binary()) -> tuple()) | term | {module(), function()}.
 -type file()    :: string().
 -type key()     :: term().
 -type option()  :: {key_element, pos_integer()} | {subscribers, [pid()]}.

--- a/src/rig_server.erl
+++ b/src/rig_server.erl
@@ -132,6 +132,10 @@ configs_validate([{BaseDir, Configs} | T], Acc) ->
 configs_validate([{Table, Filename, term, Options} | T], Acc) ->
     DecoderFun = fun erlang:binary_to_term/1,
     configs_validate(T, [{Table, Filename, DecoderFun, Options} | Acc]);
+configs_validate([{Table, Filename, {Module, Function}, Options} | T], Acc) ->
+    DecoderFun = fun Module:Function/1,
+    configs_validate(T, [{Table, Filename, DecoderFun, Options} | Acc]);
+
 configs_validate([{Table, Filename, Decoder, Options} | T], Acc) ->
     case rig_utils:parse_fun(Decoder) of
         {ok, DecoderFun} ->

--- a/test/rig_tests.erl
+++ b/test/rig_tests.erl
@@ -17,26 +17,25 @@ rig_test() ->
         {creatives, "./test/files/creatives.bert", term, []},
         {"./test/files/", [
             {domains, "domains.bert", term, [{key_element, 2}]},
+            {dummy, "domains.bert", {test_config, dummy}, [{key_element, 3}]},
             {invalid_fun, "invalid.bert", "my_fun:decode/1.", []}
         ]},
         {invalid_file, "", ?DECODER, []},
         {users, "./test/files/users.bert", ?DECODER, [{key_element, 2},
             {subscribers, [rig_test]}]}
     ]),
-    application:set_env(?APP, reload_delay, 500),
-    {ok, _} = rig_app:start(),
 
     encode_bert_configs(),
-    encode_bert_configs(),
-    encode_bert_configs(),
+    {ok, _} = rig_app:start(),
 
     receive {rig_index, update, users} ->
         ok
     end,
-    Count = length(ets:all()) - 4,
+    Count = length(ets:all()) - 5,
 
     {ok, {domain, 1 , <<"adgear.com">>}} = rig:read(domains, 1),
     {ok, {domain, 1 , <<"adgear.com">>}} = rig:read(domains, 1, undefined),
+    {ok, {domain, 5 , <<"foobar.com">>}} = rig:read(dummy, <<"foobar.com">>),
 
     {error, unknown_key} = rig:read(domains, 6),
     {ok, undefined} = rig:read(domains, 6, undefined),

--- a/test/test_config.erl
+++ b/test/test_config.erl
@@ -1,0 +1,8 @@
+-module(test_config).
+
+-export([
+    dummy/1
+]).
+
+dummy(_Bin) ->
+    {domain, 5 , <<"foobar.com">>}.


### PR DESCRIPTION
Replaces https://github.com/lpgauth/rig/pull/7. After doing a bunch of local measurements, it turns out this is just as fast while being cleaner and simpler.

For the speed improvement over a lambda, you don't actually need to use this new module method. You can just put `"fun mod:fun/1."` in the config. So while this PR adds a new way of defining things in the config it's not actually "needed".

One difference I see to the module method is it crashes when you put a nonexisting module while the `fun ...` method will be silent if you forget the dot at the end of the function.

Let me know what you think.